### PR TITLE
Use Drafter NPM Package for API Blueprint Parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 Atom Linter for [API Blueprint][]
 
 This linter plugin for [Linter][]
-provides interface to API Blueprint parser ([Protagonist][]).
+provides interface to API Blueprint parser ([Drafter][]).
 
 ## Usage
 Files with the `.apib` extension are validated on the flight.
@@ -28,13 +28,11 @@ apm install language-api-blueprint
 **Note:** The installation may take some time as it includes building of the API
 Blueprint parser from its sources.
 
-**Note:** On Windows with MSVS 2015 make sure to run `$ set GYP_MSVS_VERSION=2015` prior to `$ apm install linter-api-blueprint`.
-
 ## Contribution
 
 Much needed. Fork & pull request.
 
 [API Blueprint]: https://github.com/apiaryio/api-blueprint
 [Linter]: https://github.com/atom-community/linter
-[Protagonist]: https://github.com/apiaryio/protagonist
+[Drafter]: https://github.com/apiaryio/drafter-npm
 [Parse Result Namespace]: https://github.com/refractproject/refract-spec/blob/master/namespaces/parse-result-namespace.md

--- a/lib/main.js
+++ b/lib/main.js
@@ -2,7 +2,7 @@
 
 import {CompositeDisposable} from 'atom'
 import query from 'refract-query'
-import protagonist from 'protagonist'
+import drafter from 'drafter'
 import {
   lineEndingsIndices,
   createResolution
@@ -23,7 +23,7 @@ export default {
       const textEditor = workspace.getActiveTextEditor()
       const text = textEditor.getText()
 
-      protagonist.parse(text, {
+      drafter.parse(text, {
         generateSourceMap: false,
         type: 'refract'
       }, function(error, result) {
@@ -54,7 +54,7 @@ export default {
           const filePath = textEditor.getPath()
 
           return new Promise(function(resolve, reject) {
-            protagonist.parse(text, {
+            drafter.parse(text, {
               generateSourceMap: false,
               type: 'refract'
             }, function(error, result) {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "atom-linter": "^4.0.1",
     "atom-package-deps": "^3.0.6",
-    "protagonist": "^1.2.2",
+    "drafter": "^1.0.0",
     "refract-query": "0.0.1"
   },
   "packages-deps": [


### PR DESCRIPTION
This should make installing this atom plugin easier. Drafter NPM package optionally depends on the C++ API Blueprint Parser (Protagonist) and uses a pure JS version if it cannot be installed. If Protagonist cannot be installed, users will still be able to install and use the plugin with the pure JS parser.

See [Drafter NPM](https://github.com/apiaryio/drafter-npm) for more details.
